### PR TITLE
Use new parser form types

### DIFF
--- a/lua/nvim-paredit-fennel/extension.lua
+++ b/lua/nvim-paredit-fennel/extension.lua
@@ -5,17 +5,8 @@ local M = {}
 
 local form_types = {
   "list",
-  "let",
-  "fn",
-  "for",
-  "local",
+  "sequence",
   "table",
-  "sequential_table",
-  "quoted_list",
-  "let_clause",
-  "sequential_table_binding",
-  "parameters",
-  "each",
 }
 
 M.whitespace_chars = { " ", "," }

--- a/lua/nvim-paredit-fennel/extension.lua
+++ b/lua/nvim-paredit-fennel/extension.lua
@@ -57,18 +57,26 @@ function M.node_is_comment(node)
 end
 
 function M.get_form_edges(node)
-  local node_range = { node:range() }
+  local outer_range = { node:range() }
 
   local form = M.unwrap_form(node)
-  local form_range = { form:range() }
 
-  local left_range = { node_range[1], node_range[2] }
-  left_range[3] = form_range[1]
-  left_range[4] = form_range[2] + 1
+  local left_bracket_range = { form:field("open")[1]:range() }
+  local right_bracket_range = { form:field("close")[1]:range() }
 
-  local right_range = { form:range() }
-  right_range[1] = right_range[3]
-  right_range[2] = right_range[4] - 1
+  local left_range = {
+    outer_range[1],
+    outer_range[2],
+    left_bracket_range[3],
+    left_bracket_range[4],
+  }
+
+  local right_range = {
+    right_bracket_range[1],
+    right_bracket_range[2],
+    outer_range[3],
+    outer_range[4],
+  }
 
   local left_text = vim.api.nvim_buf_get_text(0, left_range[1], left_range[2], left_range[3], left_range[4], {})
   local right_text = vim.api.nvim_buf_get_text(0, right_range[1], right_range[2], right_range[3], right_range[4], {})


### PR DESCRIPTION
As the default parser for Fennel has changed the `form_types` are different now.

See [alexmozaidze/tree-sitter-fennel](https://github.com/alexmozaidze/tree-sitter-fennel) for the new default parser for Fennel.

I tested these changes with the following test file:

```fnl
(+ 1 2)

(+ (+ 1 2) 3 4 (- 5 6) (/ 10 (+ 20 3)))

[1 2 [3] [4 5] 6]

(fn salute []
  (print "Hello, World!"))

(macro some-macro []
  (let [v "Hello, World!"]
    `(print ,v)))

#(print "Hello, World")

(macrodebug '(print "Hello, World!"))
```

I applied all the operations and they seem to work perfectly.

A fun fact is that the reader macros are moved with the slurp and barf operations, which in my opinion is desirable:

```fnl
#(print "Hello, World!")
; '>('
print #("Hello, World!")
```

The only issues I am having right now are with the `(` and `)` movement operations, which if used after reaching the end show the following error:

```log
E5108: Error executing lua: ...vim-paredit-fennel/lua/nvim-paredit-fennel/extension.lua:15: attempt to index local 'current_node' (a nil value)
stack traceback:
        ...vim-paredit-fennel/lua/nvim-paredit-fennel/extension.lua:15: in function 'find_next_parent_form'
        ...vim-paredit-fennel/lua/nvim-paredit-fennel/extension.lua:33: in function 'get_node_root'
        .../nvim/lazy/nvim-paredit/lua/nvim-paredit/api/motions.lua:195: in function 'move_to_parent_form_edge'
        .../nvim/lazy/nvim-paredit/lua/nvim-paredit/api/motions.lua:231: in function <.../nvim/lazy/nvim-paredit/lua/nvim-paredit/api/motions.lua:230
```

And also with the `paredit.api.raise_form` operation, which fails every time with the following error:

```log
E5108: Error executing lua: ...vim-paredit-fennel/lua/nvim-paredit-fennel/extension.lua:15: attempt to index local 'current_node' (a nil value)
stack traceback:
        ...vim-paredit-fennel/lua/nvim-paredit-fennel/extension.lua:15: in function 'find_next_parent_form'
        ...vim-paredit-fennel/lua/nvim-paredit-fennel/extension.lua:33: in function 'get_node_root'
        .../nvim/lazy/nvim-paredit/lua/nvim-paredit/api/motions.lua:195: in function 'move_to_parent_form_edge'
        .../nvim/lazy/nvim-paredit/lua/nvim-paredit/api/motions.lua:231: in function <.../nvim/lazy/nvim-paredit/lua/nvim-paredit/api/motions.lua:230
```

Do you know how this could be fixed? I don't know enough about your plugin to fix it confidently.